### PR TITLE
Fix UnicodeDecodeError in setup.py on Python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,17 @@
 # Copyright (c) 2011-2013 Ivan Zakrevsky
 # Licensed under the terms of the BSD License (see LICENSE.txt)
 import os.path
+import codecs
 from setuptools import setup, find_packages
 
 app_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+
+
+def read(fname):
+    with codecs.open(os.path.join(os.path.dirname(__file__), fname), 'r', encoding='utf8') as f:
+        data = f.read()
+    return data
+
 
 setup(
     name = app_name,
@@ -17,7 +25,7 @@ setup(
     author = "Ivan Zakrevsky",
     author_email = "ivzak@yandex.ru",
     description = "Cache-dependencies (former Cache-tagging) allows you easily invalidate all cache records tagged with a given tag(s). Supports Django.",
-    long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
+    long_description=read('README.rst'),
     license = "BSD License",
     keywords = "django cache dependencies tagging",
     tests_require = [


### PR DESCRIPTION
Installation failed on Python 3.4 environment.
This commit fix the issue. As result it fortunately works in both Python 2 or 3.

```
Collecting cache-dependencies==0.7.7.47 (from -r requirements.txt (line 4))
  Using cached cache-dependencies-0.7.7.47.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-xddk6p1a/cache-dependencies/setup.py", line 20, in <module>
        long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
      File "/home/saeco_esupport/pythonenv/saeco_esupport/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 10201: ordinal not in range(128)
```